### PR TITLE
Add more stuff for multi FW support

### DIFF
--- a/offsets.py
+++ b/offsets.py
@@ -17,14 +17,19 @@ class OffsetsFirmware_750_755:
 
     MEMCPY = 0xffffffff8248f800
 
+    # Not available on FW >= 6.50
+    # 0xffffffff82200000 : mov cr0, rsi ; mov eax, 1 ; ret
+    MOV_CR0_RSI_MOV_EAX_1_RET = 0xffffffff82200000
+
+    # Not necessary on FW < 6.50
     # 0xffffffffe19d9cf9 : mov cr0, rsi ; ud2 ; mov eax, 1 ; ret
     MOV_CR0_RSI_UD2_MOV_EAX_1_RET = 0xffffffff825a2589
-    
+
     SECOND_GADGET_OFF = 0x3b
 
     # 0xffffffff824095e7 : jmp qword ptr [rsi + 0x3b]
     FIRST_GADGET = 0xffffffff824095e7
-    
+
     # 0xffffffff82c90516 : push rbp ; jmp qword ptr [rsi]
     PUSH_RBP_JMP_QWORD_PTR_RSI = 0xffffffff82c90516
 
@@ -57,7 +62,7 @@ class OffsetsFirmware_750_755:
 
     # 0xffffffff82227fa7 : pop r8 ; pop rbp ; ret
     POP_R8_POP_RBP_RET = 0xffffffff82227fa7
-    
+
     # 0xffffffff827dc32f : pop r12 ; ret
     POP_R12_RET = 0xffffffff827dc32f
 
@@ -111,6 +116,11 @@ class OffsetsFirmware_800_803:
 
     MEMCPY = 0xffffffff8245e1c0
 
+    # Not available on FW >= 6.50
+    # 0xffffffff82200000 : mov cr0, rsi ; mov eax, 1 ; ret
+    MOV_CR0_RSI_MOV_EAX_1_RET = 0xffffffff82200000
+
+    # Not necessary on FW < 6.50
     # 0xffffffff82660609 : mov cr0, rsi ; ud2 ; mov eax, 1 ; ret
     MOV_CR0_RSI_UD2_MOV_EAX_1_RET = 0xffffffff82660609
 
@@ -205,6 +215,11 @@ class OffsetsFirmware_850_852:
 
     MEMCPY = 0xffffffff825a40f0
 
+    # Not available on FW >= 6.50
+    # 0xffffffff82200000 : mov cr0, rsi ; mov eax, 1 ; ret
+    MOV_CR0_RSI_MOV_EAX_1_RET = 0xffffffff82200000
+
+    # Not necessary on FW < 6.50
     # 0xffffffff823ce849 : mov cr0, rsi ; ud2 ; mov eax, 1 ; ret
     MOV_CR0_RSI_UD2_MOV_EAX_1_RET = 0xffffffff823ce849
 
@@ -299,6 +314,11 @@ class OffsetsFirmware_900:
 
     MEMCPY = 0xffffffff824714b0
 
+    # Not available on FW >= 6.50
+    # 0xffffffff82200000 : mov cr0, rsi ; mov eax, 1 ; ret
+    MOV_CR0_RSI_MOV_EAX_1_RET = 0xffffffff82200000
+
+    # Not necessary on FW < 6.50
     # 0xffffffff823fb949 : mov cr0, rsi ; ud2 ; mov eax, 1 ; ret
     MOV_CR0_RSI_UD2_MOV_EAX_1_RET = 0xffffffff823fb949
 
@@ -392,6 +412,11 @@ class OffsetsFirmware_903_904:
 
     MEMCPY = 0xffffffff82471130
 
+    # Not available on FW >= 6.50
+    # 0xffffffff82200000 : mov cr0, rsi ; mov eax, 1 ; ret
+    MOV_CR0_RSI_MOV_EAX_1_RET = 0xffffffff82200000
+
+    # Not necessary on FW < 6.50
     # 0xffffffff823fb679 : mov cr0, rsi ; ud2 ; mov eax, 1 ; ret
     MOV_CR0_RSI_UD2_MOV_EAX_1_RET = 0xffffffff823fb679
 
@@ -486,6 +511,12 @@ class OffsetsFirmware_950_960:
 
     MEMCPY = 0xffffffff82401cc0
 
+    # Not available on FW >= 6.50
+    # 0xffffffff82200000 : mov cr0, rsi ; mov eax, 1 ; ret
+    MOV_CR0_RSI_MOV_EAX_1_RET = 0xffffffff82200000
+
+    # Not necessary on FW < 6.50
+    # 0xffffffff822bea79 : mov cr0, rsi ; ud2 ; mov eax, 1 ; ret
     MOV_CR0_RSI_UD2_MOV_EAX_1_RET = 0xffffffff822bea79
 
     SECOND_GADGET_OFF = 0x3b
@@ -579,6 +610,11 @@ class OffsetsFirmware_1000_1001:
 
     MEMCPY = 0xffffffff82672d20
 
+    # Not available on FW >= 6.50
+    # 0xffffffff82200000 : mov cr0, rsi ; mov eax, 1 ; ret
+    MOV_CR0_RSI_MOV_EAX_1_RET = 0xffffffff82200000
+
+    # Not necessary on FW < 6.50
     # 0xffffffff82376089 : mov cr0 rsi ; ud2 ; mov eax 1; ret
     MOV_CR0_RSI_UD2_MOV_EAX_1_RET = 0xffffffff82376089
 
@@ -673,6 +709,12 @@ class OffsetsFirmware_1050_1071:
 
     MEMCPY = 0xffffffff822d7370
 
+    # Not available on FW >= 6.50
+    # 0xffffffff82200000 : mov cr0, rsi ; mov eax, 1 ; ret
+    MOV_CR0_RSI_MOV_EAX_1_RET = 0xffffffff82200000
+
+    # Not necessary on FW < 6.50
+    # 0xffffffff82285f39 : mov cr0 rsi ; ud2 ; mov eax 1; ret
     MOV_CR0_RSI_UD2_MOV_EAX_1_RET = 0xffffffff82285f39
 
     SECOND_GADGET_OFF = 0x3b
@@ -766,6 +808,11 @@ class OffsetsFirmware_1100:
 
     MEMCPY = 0xffffffff824dddf0
 
+    # Not available on FW >= 6.50
+    # 0xffffffff82200000 : mov cr0, rsi ; mov eax, 1 ; ret
+    MOV_CR0_RSI_MOV_EAX_1_RET = 0xffffffff82200000
+
+    # Not necessary on FW < 6.50
     # 0xffffffff824f1299 : mov cr0, rsi ; ud2 ; mov eax, 1 ; ret
     MOV_CR0_RSI_UD2_MOV_EAX_1_RET = 0xffffffff824f1299
 

--- a/stage2/stage2.c
+++ b/stage2/stage2.c
@@ -127,13 +127,19 @@ void stage2(void) {
   uint8_t nops[] = {0x90, 0x90, 0x90};
 
   *(uint16_t *)kdlsym(copyin_patch1) = 0x9090;
+#if FIRMWARE >= 550
   memcpy((void *)kdlsym(copyin_patch2), nops, sizeof(nops));
+#endif
 
   *(uint16_t *)kdlsym(copyout_patch1) = 0x9090;
+#if FIRMWARE >= 550
   memcpy((void *)kdlsym(copyout_patch2), nops, sizeof(nops));
+#endif
 
   *(uint16_t *)kdlsym(copyinstr_patch1) = 0x9090;
+#if FIRMWARE >= 550
   memcpy((void *)kdlsym(copyinstr_patch2), nops, sizeof(nops));
+#endif
   *(uint16_t *)kdlsym(copyinstr_patch3) = 0x9090;
 
   // Restore write protection


### PR DESCRIPTION
- < 5.50 needs less patching for copyin/copyout/copyinstr
- < 6.50 did not need veri patches
- < 6.50 does not require changes for ud2 instruction

Figured I'd add it here as the FW detection I had in mine will create a conflict.